### PR TITLE
Fixed the text color for the address in the dark theme on the session…

### DIFF
--- a/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebConsolePage.kt
+++ b/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebConsolePage.kt
@@ -38,11 +38,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -335,7 +338,10 @@ fun BrowserPreview(context: Context, isHttps: Boolean, httpPort: Int, httpsPort:
                 ClickableText(
                     text = AnnotatedString(defaultUrl),
                     modifier = Modifier.padding(start = 16.dp),
-                    style = MaterialTheme.typography.titleLarge.copy(fontSize = 16.sp),
+                    style = TextStyle(
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 16.sp
+                    ),
                     onClick = {
                         val clip = ClipData.newPlainText(LocaleHelper.getString(R.string.link), defaultUrl)
                         clipboardManager.setPrimaryClip(clip)


### PR DESCRIPTION
Hi,

This is small pull request addresses the issue of incorrect text color in the dark theme of the Plain app. The text color for the address on the session screen was displaying as black, making it hard to read. With this fix, the text color has been adjusted to ensure proper visibility and readability in the dark theme.

# Changes Made:

Adjusted text color for address in the dark theme on the session screen.
## Screenshots:
### Before :
<img height=400 src="https://github.com/ismartcoding/plain-app/assets/45008991/343908c2-981d-41dc-9423-b19b517dee68">

### After (Adjusted Color):
<img height=400 src="https://github.com/ismartcoding/plain-app/assets/45008991/3924144b-4a43-4be2-b3a4-31c0d98beccc">


Your feedback on this pull request is appreciated.

Thank you,