### PR TITLE
Fix missing import from changes in 9147468

### DIFF
--- a/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebSettingsPage.kt
+++ b/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebSettingsPage.kt
@@ -47,6 +47,7 @@ import com.ismartcoding.plain.powerManager
 import com.ismartcoding.plain.preferences.ApiPermissionsPreference
 import com.ismartcoding.plain.preferences.LocalApiPermissions
 import com.ismartcoding.plain.preferences.LocalKeepAwake
+import com.ismartcoding.plain.preferences.WebPreference
 import com.ismartcoding.plain.preferences.WebSettingsProvider
 import com.ismartcoding.plain.services.PNotificationListenerService
 import com.ismartcoding.plain.ui.base.ActionButtonMoreWithMenu


### PR DESCRIPTION
After fix for #244 was merged with 91474681205081a1c33f5e721f94a997ddd95160, project doesn't build with missing definition error:
```
> Task :app:compileGithubReleaseKotlin FAILED
e: file:///<workspace>/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebSettingsPage.kt:103:74 Unresolved reference 'WebPreference'.
e: file:///<workspace>/app/src/main/java/com/ismartcoding/plain/ui/page/web/WebSettingsPage.kt:130:38 Unresolved reference 'WebPreference'.
``` 