### PR TITLE
Fix search bar focus issue on desktop web interface (#248)

### DIFF
--- a/app/src/main/java/com/ismartcoding/plain/ui/components/ListSearchBar.kt
+++ b/app/src/main/java/com/ismartcoding/plain/ui/components/ListSearchBar.kt
@@ -32,6 +32,12 @@ fun <T : IData> ListSearchBar(
 ) {
     val focusRequester = remember { FocusRequester() }
     val windowInfo = LocalWindowInfo.current
+    
+    // Request focus immediately when the search bar is first displayed (issue #248)
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+    
     LaunchedEffect(windowInfo) {
         snapshotFlow { windowInfo.isWindowFocused }.collect { isWindowFocused ->
             if (isWindowFocused && viewModel.searchActive.value) {


### PR DESCRIPTION
### Summary
This PR fixes the UX issue where clicking the search button in the Files section via web browser doesn't automatically focus the search text field, requiring users to manually tab or click into it.

### Problem
When users access PlainApp through a web browser and try to search files:
1. Click the search button
2. Search field appears, but the cursor is not in the text field
3. Users must press Tab or manually click into the field before typing

This creates an extra step and breaks the expected user flow.

### Solution
Added a `LaunchedEffect(Unit)` in `ListSearchBar.kt` to request focus immediately when the search bar is first displayed. This ensures the cursor is positioned in the search field right away, allowing users to start typing immediately.

### Changes
**File modified**: `app/src/main/java/com/ismartcoding/plain/ui/components/ListSearchBar.kt`

**Code added**:
```kotlin
// Request focus immediately when the search bar is first displayed (issue #248)
LaunchedEffect(Unit) {
    focusRequester.requestFocus()
}